### PR TITLE
Improve handling of permanent connection errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
       "name": "Python Debug Polebot",
       "type": "debugpy",
       "request": "launch",
-      "module": "polebot"
+      "module": "polebot",
+      "justMyCode": false,
     },
     {
       "name": "Docker: Python - General",

--- a/src/polebot/app_config.py
+++ b/src/polebot/app_config.py
@@ -9,11 +9,15 @@ class AppConfig:
 
     config_dir: str = environ.var(".config")
 
+    max_websocket_connection_attempts: int = environ.var(
+        0, help="The maximum number of attempts to connect to a websocket.",
+    )
+
     @environ.config
     class MongoConfig:
         """Configuration for the MongoDB connection."""
 
-        connection_string: str = environ.var("mongodb://localhost:27017/")
-        db_name: str = environ.var("polebot")
+        connection_string: str = environ.var("mongodb://localhost:27017/", help="The connection string for MongoDB.")
+        db_name: str = environ.var("polebot", help="The name of the database to use in MongoDB.")
 
     mongodb: MongoConfig = environ.group(MongoConfig)

--- a/src/polebot/exceptions.py
+++ b/src/polebot/exceptions.py
@@ -1,6 +1,18 @@
 """This module contains custom exceptions that are used throughout the application."""
 
 
+class WebsocketConnectionError(Exception):
+    """The exception raised when a websocket connection error occurs."""
+
+    def __init__(self, message: str) -> None:
+        """Creates a new instance of `WebsocketConnectionError`.
+
+        Args:
+            message (str): Indicates the error that occurred.
+        """
+        self.message = message
+        super().__init__(self.message)
+
 class LogStreamMessageError(Exception):
     """The exception raised when the log stream returns a message indicating an error."""
 

--- a/src/polebot/utils.py
+++ b/src/polebot/utils.py
@@ -18,6 +18,7 @@ def backoff(
     min_delay: float = BACKOFF_MIN_DELAY,
     max_delay: float = BACKOFF_MAX_DELAY,
     factor: float = BACKOFF_FACTOR,
+    max_attempts: int = 0,
 ) -> Generator[float]:
     """Generate a series of backoff delays between reconnection attempts.
 
@@ -25,15 +26,19 @@ def backoff(
         How many seconds to wait before retrying to connect.
 
     """
+    attempts = 0
     # Add a random initial delay between 0 and 5 seconds.
     # See 7.2.3. Recovering from Abnormal Closure in RFC 6455.
     yield random.random() * initial_delay  # noqa: S311 - cryptographic security not required
+    attempts += 1
     delay = min_delay
-    while delay < max_delay:
+    while delay < max_delay and (max_attempts == 0 or attempts < max_attempts):
         yield delay
+        attempts += 1
         delay *= factor
-    while True:
+    while max_attempts == 0 or attempts < max_attempts:
         yield max_delay
+        attempts += 1
 
 
 def expand_environment(value: str) -> str:


### PR DESCRIPTION
This PR adds the capability to abandon websocket connection attempts after a configurable number of retries (e.g. due to an auth failure). The default behaviour is to retry indefinitely, but a configuration setting enables failure.