### PR TITLE
Fix DI and Ruff

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,4 @@
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "ruff.nativeServer": "off"
 }

--- a/play/algorithm_investigations.ipynb
+++ b/play/algorithm_investigations.ipynb
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1592,7 +1592,6 @@
    ],
    "source": [
     "# Create a dataframe that joins the maps to the configuration parameters\n",
-    "from pickletools import dis\n",
     "\n",
     "\n",
     "df = (\n",

--- a/play/result_analysis.ipynb
+++ b/play/result_analysis.ipynb
@@ -2,11 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import pandas as pd\n",
     "import json\n",
     "from pathlib import Path"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1782,29 +1782,29 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "ruff"
-version = "0.8.4"
+version = "0.9.5"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.8.4-py3-none-linux_armv6l.whl", hash = "sha256:58072f0c06080276804c6a4e21a9045a706584a958e644353603d36ca1eb8a60"},
-    {file = "ruff-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ffb60904651c00a1e0b8df594591770018a0f04587f7deeb3838344fe3adabac"},
-    {file = "ruff-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ddf5d654ac0d44389f6bf05cee4caeefc3132a64b58ea46738111d687352296"},
-    {file = "ruff-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e248b1f0fa2749edd3350a2a342b67b43a2627434c059a063418e3d375cfe643"},
-    {file = "ruff-0.8.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf197b98ed86e417412ee3b6c893f44c8864f816451441483253d5ff22c0e81e"},
-    {file = "ruff-0.8.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c41319b85faa3aadd4d30cb1cffdd9ac6b89704ff79f7664b853785b48eccdf3"},
-    {file = "ruff-0.8.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:9f8402b7c4f96463f135e936d9ab77b65711fcd5d72e5d67597b543bbb43cf3f"},
-    {file = "ruff-0.8.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4e56b3baa9c23d324ead112a4fdf20db9a3f8f29eeabff1355114dd96014604"},
-    {file = "ruff-0.8.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:736272574e97157f7edbbb43b1d046125fce9e7d8d583d5d65d0c9bf2c15addf"},
-    {file = "ruff-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fe710ab6061592521f902fca7ebcb9fabd27bc7c57c764298b1c1f15fff720"},
-    {file = "ruff-0.8.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:13e9ec6d6b55f6da412d59953d65d66e760d583dd3c1c72bf1f26435b5bfdbae"},
-    {file = "ruff-0.8.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:97d9aefef725348ad77d6db98b726cfdb075a40b936c7984088804dfd38268a7"},
-    {file = "ruff-0.8.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ab78e33325a6f5374e04c2ab924a3367d69a0da36f8c9cb6b894a62017506111"},
-    {file = "ruff-0.8.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8ef06f66f4a05c3ddbc9121a8b0cecccd92c5bf3dd43b5472ffe40b8ca10f0f8"},
-    {file = "ruff-0.8.4-py3-none-win32.whl", hash = "sha256:552fb6d861320958ca5e15f28b20a3d071aa83b93caee33a87b471f99a6c0835"},
-    {file = "ruff-0.8.4-py3-none-win_amd64.whl", hash = "sha256:f21a1143776f8656d7f364bd264a9d60f01b7f52243fbe90e7670c0dfe0cf65d"},
-    {file = "ruff-0.8.4-py3-none-win_arm64.whl", hash = "sha256:9183dd615d8df50defa8b1d9a074053891ba39025cf5ae88e8bcb52edcc4bf08"},
-    {file = "ruff-0.8.4.tar.gz", hash = "sha256:0d5f89f254836799af1615798caa5f80b7f935d7a670fad66c5007928e57ace8"},
+    {file = "ruff-0.9.5-py3-none-linux_armv6l.whl", hash = "sha256:d466d2abc05f39018d53f681fa1c0ffe9570e6d73cde1b65d23bb557c846f442"},
+    {file = "ruff-0.9.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38840dbcef63948657fa7605ca363194d2fe8c26ce8f9ae12eee7f098c85ac8a"},
+    {file = "ruff-0.9.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d56ba06da53536b575fbd2b56517f6f95774ff7be0f62c80b9e67430391eeb36"},
+    {file = "ruff-0.9.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f7cb2a01da08244c50b20ccfaeb5972e4228c3c3a1989d3ece2bc4b1f996001"},
+    {file = "ruff-0.9.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96d5c76358419bc63a671caac70c18732d4fd0341646ecd01641ddda5c39ca0b"},
+    {file = "ruff-0.9.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:deb8304636ed394211f3a6d46c0e7d9535b016f53adaa8340139859b2359a070"},
+    {file = "ruff-0.9.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df455000bf59e62b3e8c7ba5ed88a4a2bc64896f900f311dc23ff2dc38156440"},
+    {file = "ruff-0.9.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de92170dfa50c32a2b8206a647949590e752aca8100a0f6b8cefa02ae29dce80"},
+    {file = "ruff-0.9.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d28532d73b1f3f627ba88e1456f50748b37f3a345d2be76e4c653bec6c3e393"},
+    {file = "ruff-0.9.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c746d7d1df64f31d90503ece5cc34d7007c06751a7a3bbeee10e5f2463d52d2"},
+    {file = "ruff-0.9.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11417521d6f2d121fda376f0d2169fb529976c544d653d1d6044f4c5562516ee"},
+    {file = "ruff-0.9.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b9d71c3879eb32de700f2f6fac3d46566f644a91d3130119a6378f9312a38e1"},
+    {file = "ruff-0.9.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2e36c61145e70febcb78483903c43444c6b9d40f6d2f800b5552fec6e4a7bb9a"},
+    {file = "ruff-0.9.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f71d09aeba026c922aa7aa19a08d7bd27c867aedb2f74285a2639644c1c12f5"},
+    {file = "ruff-0.9.5-py3-none-win32.whl", hash = "sha256:134f958d52aa6fdec3b294b8ebe2320a950d10c041473c4316d2e7d7c2544723"},
+    {file = "ruff-0.9.5-py3-none-win_amd64.whl", hash = "sha256:78cc6067f6d80b6745b67498fb84e87d32c6fc34992b52bffefbdae3442967d6"},
+    {file = "ruff-0.9.5-py3-none-win_arm64.whl", hash = "sha256:18a29f1a005bddb229e580795627d297dfa99f16b30c7039e73278cf6b5f9fa9"},
+    {file = "ruff-0.9.5.tar.gz", hash = "sha256:11aecd7a633932875ab3cb05a484c99970b9d52606ce9ea912b690b02653d56c"},
 ]
 
 [[package]]
@@ -2257,4 +2257,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "0914e8cf938c9a1cefbdf5a2ece55109f0223755d43222e880f41ba9db458f6d"
+content-hash = "5988f2a4ebd2ec506cb3a13309f2fe9bb15b07c61cd4342b8530f322090d1fd6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ motor = "^3.6.0"
 discord-py = "^2.4.0"
 
 [tool.poetry.group.dev.dependencies]
-ruff = "0.8.4"
+ruff = "^0.9.5"
 mypy = "^1.13.0"
 pyright = "^1.1.388"
 pytest = "^8.3.3"
@@ -88,96 +88,96 @@ ignore_errors = true
 disallow_untyped_defs = false
 
 
-[tool.ruff]
-exclude = ["scripts", "docs", "out", "play"]
-cache-dir = ".ruff_cache"
-line-length = 120
-indent-width = 4
-target-version = "py312"
+# [tool.ruff]
+# exclude = ["scripts", "docs", "out", "play"]
+# cache-dir = ".ruff_cache"
+# line-length = 120
+# indent-width = 4
+# target-version = "py312"
 
-[tool.ruff.format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
-# Like Black, indent with spaces, rather than tabs.
-indent-style = "space"
-# Like Black, respect magic trailing commas.
-skip-magic-trailing-comma = false
+# [tool.ruff.format]
+# # Like Black, use double quotes for strings.
+# quote-style = "double"
+# # Like Black, indent with spaces, rather than tabs.
+# indent-style = "space"
+# # Like Black, respect magic trailing commas.
+# skip-magic-trailing-comma = false
 
-[tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
-# McCabe complexity (`C901`) by default.
-select = [
-    # pycodestyle errors
-    "E",
-    # pycodestyle warnings
-    "W",
-    # Pyflakes
-    "F",
-    # pyupgrade
-    "UP",
-    # flake8-bugbear
-    "B",
-    # flake8-simplify
-    "SIM",
-    # isort
-    "I",
-    # pep8-naming
-    "N",
-    # flake8-comprehensions
-    "C4",
-    # pydocstyle
-    "D",
-    # flake8-2020
-    "YTT",
-    # flake8-annotations
-    "ANN",
-    # flake8-async
-    "ASYNC",
-    # flake8-bandit
-    "S",
-    # flake8-blind-except
-    "BLE",
-    # flake8-builtins
-    "A",
-    # flake8-commas
-    "COM",
-    # flake8-datetimez
-    "DTZ",
-    # flake8-import-conventions
-    "ICN",
-    # flake8-logging
-    "LOG",
-    # flake8-logging-format
-    "G",
-    # flake8-pie
-    "PIE",
-    # flake8-print
-    "T20",
-    # flake8-use-pathlib
-    "PTH",
-    ]
-ignore = ["D1", "UP007"]
-
-
-# Allow fix for all enabled rules (when `--fix`) is provided.
-fixable = ["ALL"]
-unfixable = []
-
-# Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+# [tool.ruff.lint]
+# # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# # McCabe complexity (`C901`) by default.
+# select = [
+#     # pycodestyle errors
+#     "E",
+#     # pycodestyle warnings
+#     "W",
+#     # Pyflakes
+#     "F",
+#     # pyupgrade
+#     "UP",
+#     # flake8-bugbear
+#     "B",
+#     # flake8-simplify
+#     "SIM",
+#     # isort
+#     "I",
+#     # pep8-naming
+#     "N",
+#     # flake8-comprehensions
+#     "C4",
+#     # pydocstyle
+#     "D",
+#     # flake8-2020
+#     "YTT",
+#     # flake8-annotations
+#     "ANN",
+#     # flake8-async
+#     "ASYNC",
+#     # flake8-bandit
+#     "S",
+#     # flake8-blind-except
+#     "BLE",
+#     # flake8-builtins
+#     "A",
+#     # flake8-commas
+#     "COM",
+#     # flake8-datetimez
+#     "DTZ",
+#     # flake8-import-conventions
+#     "ICN",
+#     # flake8-logging
+#     "LOG",
+#     # flake8-logging-format
+#     "G",
+#     # flake8-pie
+#     "PIE",
+#     # flake8-print
+#     "T20",
+#     # flake8-use-pathlib
+#     "PTH",
+#     ]
+# ignore = ["D1", "UP007"]
 
 
-[tool.ruff.lint.isort]
-known-local-folder = ["src"]
+# # Allow fix for all enabled rules (when `--fix`) is provided.
+# fixable = ["ALL"]
+# unfixable = []
 
-[tool.ruff.lint.per-file-ignores]
-"*.ipynb" = ["E402"]
-"src/polebot/api_models.py" = [
-    "UP",
-    "D",
-] # this file is copied from hll_rcon_tool code so we don't want to modify it
-"tests/*" = ["D", "ANN", "S"]
+# # Allow unused variables when underscore-prefixed.
+# dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+
+# [tool.ruff.lint.isort]
+# known-local-folder = ["src"]
+
+# [tool.ruff.lint.per-file-ignores]
+# "*.ipynb" = ["E402"]
+# "src/polebot/api_models.py" = [
+#     "UP",
+#     "D",
+# ] # this file is copied from hll_rcon_tool code so we don't want to modify it
+# "tests/*" = ["D", "ANN", "S"]
+
+# [tool.ruff.lint.pydocstyle]
+# convention = "google"

--- a/src/crcon/__init__.py
+++ b/src/crcon/__init__.py
@@ -4,7 +4,7 @@ from yarl import URL
 
 from .api_client import ApiClient
 from .exceptions import ApiClientError, LogStreamMessageError, WebsocketConnectionError
-from .log_stream_client import LogStreamClient, LogStreamClientConfig
+from .log_stream_client import LogStreamClient, LogStreamClientSettings
 from .server_connection_details import ServerConnectionDetails
 
 
@@ -19,13 +19,19 @@ def _validate_api_url(_instance: Any, _attribute: Any, value: URL) -> None:  # n
 
 
 def _str_to_url(val: str) -> URL:
-    return URL(val).with_query(None).with_fragment(None).with_user(None).with_password(None)
+    return (
+        URL(val)
+        .with_query(None)
+        .with_fragment(None)
+        .with_user(None)
+        .with_password(None)
+    )
 
 
 __all__ = [
     "ApiClient",
     "LogStreamClient",
-    "LogStreamClientConfig",
+    "LogStreamClientSettings",
     "ApiClientError",
     "LogStreamMessageError",
     "WebsocketConnectionError",

--- a/src/polebot/__main__.py
+++ b/src/polebot/__main__.py
@@ -12,7 +12,7 @@ import uvloop
 from dotenv import load_dotenv
 from lagom import Container
 
-from utils.logging import configure_logger
+from utils.log_tools import configure_logger
 
 from .app_config import AppConfig
 from .composition_root import (


### PR DESCRIPTION
This PR fixes an error in the DI configuration for `LogStreamClientSettings` introduced in the previous commit.

It also switches to using the Ruff native server now that the LSP has been deprecated by the extension.