### PR TITLE
Allow $id and $schema attributes in weighting JSON schema

### DIFF
--- a/src/polebot/services/settings_loader/weighting_parameters.schema.json
+++ b/src/polebot/services/settings_loader/weighting_parameters.schema.json
@@ -1,9 +1,17 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.com/weighting_parameters.schema.json",
+  "$id": "https://github.com/bwcc-clan/polebot/blob/main/src/polebot/services/settings_loader/weighting_parameters.schema.json",
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "$id": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
     "groups": {
       "$ref": "#/$defs/map_groups"
     },

--- a/tests/polebot/services/test_settings_loader.py
+++ b/tests/polebot/services/test_settings_loader.py
@@ -37,6 +37,36 @@ def describe_load_weighting_parameters():
             assert result.environments["env1"].repeat_decay == 0.5
             assert result.environments["env1"].environments == ["day", "dusk"]
 
+    def when_json_contains_schema_ref():
+
+        def returns_weighting_parameters(sut):
+            sut = SettingsLoader()
+            content = """{
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "$id": "https://example.com/weighting_parameters.schema.json",
+                "groups": {
+                    "group1": {
+                        "weight": 80,
+                        "repeat_decay": 0.5,
+                        "maps": ["map1", "map2"]
+                    }
+                },
+                "environments": {
+                    "env1": {
+                        "weight": 50,
+                        "repeat_decay": 0.5,
+                        "environments": ["day", "dusk"]
+                    }
+                }
+            }"""
+            result = sut.load_weighting_parameters(content)
+            assert not isinstance(result, list)
+            assert result.groups["group1"].weight == 80
+            assert result.groups["group1"].repeat_decay == 0.5
+            assert result.groups["group1"].maps == ["map1", "map2"]
+            assert result.environments["env1"].weight == 50
+            assert result.environments["env1"].repeat_decay == 0.5
+            assert result.environments["env1"].environments == ["day", "dusk"]
     def when_json_file_is_invalid():
 
         def detects_missing_groups(sut: SettingsLoader):


### PR DESCRIPTION
This PR allows an uploaded JSON weighting parameters file to include the `$id` and `$schema` properties.